### PR TITLE
adding a persist mode activated from the command line

### DIFF
--- a/scripts/key_teleop.py
+++ b/scripts/key_teleop.py
@@ -4,9 +4,10 @@
 import curses
 import math
 import rospy
+import sys
 from geometry_msgs.msg import Twist
 
-def main(stdscr):
+def main(stdscr, persist):
     pub = rospy.Publisher('cmd_vel', Twist, queue_size=1)
     rospy.init_node('key_teleop', anonymous=True)
     rate = rospy.Rate(10) 
@@ -18,9 +19,12 @@ def main(stdscr):
     stdscr.addstr(" - e/r        : control angular z\n")
     stdscr.addstr(" - any key    : reset of the twist\n")
     stdscr.addstr(" - ESC        : reset twist and exit\n")
+    # We will wait for 100 ms for a key to be pressed
+    if(persist): stdscr.timeout(100)
     while (not rospy.is_shutdown()) and (keycode != 27): # 27 is escape
         keycode = stdscr.getch() # read pressed key
-        if keycode == curses.KEY_UP      : twist.linear.x  = twist.linear.x  + .1
+        if keycode == -1                 : pass # No key has been pressed
+        elif keycode == curses.KEY_UP    : twist.linear.x  = twist.linear.x  + .1
         elif keycode == curses.KEY_DOWN  : twist.linear.x  = twist.linear.x  - .1
         elif keycode == curses.KEY_LEFT  : twist.linear.y  = twist.linear.y  + .1
         elif keycode == curses.KEY_RIGHT : twist.linear.y  = twist.linear.y  - .1
@@ -32,7 +36,8 @@ def main(stdscr):
 
 # Starts curses (terminal handling) and run our main function.
 if __name__ == '__main__':
+    persist = '--persist' in rospy.myargv(argv=sys.argv)
     try:
-        curses.wrapper(main)
+        curses.wrapper(lambda w: main(w,persist))
     except rospy.ROSInterruptException:
         pass


### PR DESCRIPTION
You can now launch the node as :

Without the persist mode : waiting for a key press event is blocking, i.e. the command on cmd_vel is issued only when a key is pressed

**rosrun demo_teleop key_teleop.py**

With the persist mode : there is a timeout of 100 ms; pressing a key changes the posted cmd_vel  ; If no key is pressed before the timeout, the previous cmd_vel is posted

**rosrun demo_teleop key_teleop.py --persist**
